### PR TITLE
Update to 1.21.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT' apply false
+    id 'fabric-loom' version '1.13-SNAPSHOT' apply false
     id 'net.neoforged.moddev' version '2.0.107' apply false
     id 'io.github.flemmli97.multiloader.platform-common' version '1.+' apply false
 }

--- a/fabric/src/main/java/io/github/flemmli97/linguabib/fabric/LinguaBibFabric.java
+++ b/fabric/src/main/java/io/github/flemmli97/linguabib/fabric/LinguaBibFabric.java
@@ -14,7 +14,6 @@ import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.resources.ResourceManager;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -24,16 +23,14 @@ public class LinguaBibFabric implements ModInitializer {
     @Override
     public void onInitialize() {
         ResourceManagerHelper.get(PackType.SERVER_DATA).registerReloadListener(new IdentifiableResourceReloadListener() {
-
             @Override
             public ResourceLocation getFabricId() {
                 return ServerLangManager.ID;
             }
 
             @Override
-            public CompletableFuture<Void> reload(PreparationBarrier barrier, ResourceManager manager, Executor backgroundExecutor, Executor gameExecutor) {
-                return ServerLangManager.INSTANCE
-                        .reload(barrier, manager, backgroundExecutor, gameExecutor);
+            public CompletableFuture<Void> reload(SharedState sharedState, Executor executor, PreparationBarrier preparationBarrier, Executor executor2) {
+                return ServerLangManager.INSTANCE.reload(sharedState, executor, preparationBarrier, executor2);
             }
         });
         PayloadTypeRegistry.playS2C().register(S2CLangData.TYPE, S2CLangData.STREAM_CODEC);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.jvmargs=-Xmx4G
 enabled_platforms=fabric,neoforge
-minecraft_version=1.21.8
-neoForm_version=1.21.8-20250717.133445
-parchment_minecraft=1.21.8
-parchment_version=2025.07.18
+minecraft_version=1.21.10
+neoForm_version=1.21.10-20251010.172816
+parchment_minecraft=1.21.10
+parchment_version=2025.10.12
 # NeoForge Properties
 neo_loader_version=2
-neoforge_version=21.8.13
+neoforge_version=21.10.64
 # Fabric Properties
-fabric_loader_version=0.16.14
+fabric_loader_version=0.18.1
 
 # Mod Properties
 mod_version=1.0.6
@@ -18,8 +18,8 @@ mod_author=flemmli97
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.129.0+1.21.8
-fabric_permissions_api=0.4.0
+fabric_version=0.138.3+1.21.10
+fabric_permissions_api=0.5.0
 ftb_ranks=2100.1.0
 
 # Other

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Port to 1.21.10

Updating dependencies requires higher versions of Fabric Loom, which breaks the [Gradle Scripts](https://github.com/Flemmli97/GradleScripts/tree/multiloader-mdg-plugin).
You will need to fix these to build the project.
- Loom 1.11+
  - Replace [this line](https://github.com/Flemmli97/GradleScripts/blob/multiloader-mdg-plugin/src/main/groovy/io.github.flemmli97.multiloader.platform-fabric.gradle#L51) with `artifact.moduleVersion.id.group.contains(it.group) && artifact.moduleVersion.id.name.startsWith(it.name) && it.version == artifact.moduleVersion.id.version`
  - Because the artifact name that loom outputs now has a suffix and no longer exactly matches.
- Loom 1.14+
  - Doesn't directly affect this PR, but will be required for 1.21.11 builds (fabric permissions api 0.6.0 requires it).
  - Replace any usages of `archivesBaseName` (deprecated) in gradle with `base.archivesName`, as Loom 1.14+ requires gradle 9+ where this deprecated property no longer exists.