### PR TITLE
Update to Minecraft 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 org.gradle.jvmargs=-Xmx4G
 jvm=25
-minecraft_version=26.1.2
-neoForm_version=26.1.2-1
+minecraft_version=26.2
+neoForm_version=26.2-1
 # NeoForge Properties
-neoforge_version=26.1.2.30-beta
+neoforge_version=26.2.0.6-beta
 # Fabric Properties
-fabric_loader_version=0.18.4
+fabric_loader_version=0.19.3
 
 # Mod Properties
 mod_version=1.0.6
@@ -14,7 +14,7 @@ mod_id=lingua_bib
 mod_author=flemmli97
 
 # Dependencies
-fabric_api_version=0.147.0+26.1.2
+fabric_api_version=0.152.1+26.2
 fabric_permissions_api=0.7.0
 ftb_ranks=2100.1.0
 


### PR DESCRIPTION
Bumps LinguaBibliotheca to **Minecraft 26.2**.

### Changes
`gradle.properties` only — no source changes were needed; the library compiles cleanly against 26.2 as-is.

| Property | 26.1.2 | 26.2 |
|---|---|---|
| `minecraft_version` | 26.1.2 | 26.2 |
| `neoForm_version` | 26.1.2-1 | 26.2-1 |
| `neoforge_version` | 26.1.2.30-beta | 26.2.0.6-beta |
| `fabric_loader_version` | 0.18.4 | 0.19.3 |
| `fabric_api_version` | 0.147.0+26.1.2 | 0.152.1+26.2 |

### Testing
`./gradlew build` passes for both Fabric and NeoForge. `publishToMavenLocal` produces the expected `lingua_bib:26.2-1.0.6-{common,fabric,neoforge}` artifacts.

Targeting the `26.1` branch since there's no `26.2` branch yet — happy to retarget if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)